### PR TITLE
Should import lodash methods independently to reduce bundle size

### DIFF
--- a/lib/rindle.js
+++ b/lib/rindle.js
@@ -26,8 +26,12 @@
  * @module rindle
  */
 
-var _ = require('lodash');
 var Promise = require('bluebird');
+var each = require('lodash/each');
+var head = require('lodash/head');
+var isEmpty = require('lodash/isEmpty');
+var isString = require('lodash/isString');
+var values = require('lodash/values');
 var stringToStream = require('string-to-stream');
 
 /**
@@ -66,7 +70,7 @@ exports.wait = function(stream, callback) {
 
   return new Promise(function(resolve, reject) {
     var done = function() {
-      return resolve(_.values(arguments));
+      return resolve(values(arguments));
     };
 
 		stream.on('error', reject);
@@ -177,7 +181,7 @@ exports.bifurcate = function(stream, output1, output2, callback) {
 exports.pipeWithEvents = function(stream, output, events) {
   'use strict';
 
-  _.each(events, function(event) {
+  each(events, function(event) {
     stream.on(event, function() {
       var args = Array.prototype.slice.call(arguments);
       args.unshift(event);
@@ -215,11 +219,11 @@ exports.onEvent = function(stream, event, callback) {
     stream.on(event, function() {
       var args = Array.prototype.slice.call(arguments);
 
-      if (_.isEmpty(args)) {
+      if (isEmpty(args)) {
         args = undefined;
       }
       else if (args.length === 1) {
-        args = _.head(args);
+        args = head(args);
       }
 
       return resolve(args);
@@ -244,7 +248,7 @@ exports.onEvent = function(stream, event, callback) {
 exports.getStreamFromString = function(string) {
   'use strict';
 
-  if (!_.isString(string)) {
+  if (!isString(string)) {
     throw new Error('Not a string: ' + string);
   }
 


### PR DESCRIPTION
Allows us to drop the balena-sdk minified bundle size by ~71kb.

Resolves: #6
See: https://github.com/balena-io/balena-sdk/issues/631
See: https://github.com/balena-io/balena-sdk/issues/250
Change-type: patch
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>