### PR TITLE
Drop the getStreamFromString method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ Documentation
 
 
 * [rindle](#module_rindle)
-  * [.wait(stream, callback)](#module_rindle.wait)
-  * [.extract(stream, callback)](#module_rindle.extract)
-  * [.bifurcate(stream, output1, output2, callback)](#module_rindle.bifurcate)
-  * [.pipeWithEvents(stream, output, events)](#module_rindle.pipeWithEvents) ⇒ <code>StreamReadable</code>
-  * [.onEvent(stream, event, callback)](#module_rindle.onEvent)
-  * [.getStreamFromString(string)](#module_rindle.getStreamFromString) ⇒ <code>ReadableStream</code>
+    * [.wait(stream)](#module_rindle.wait)
+    * [.extract(stream)](#module_rindle.extract)
+    * [.bifurcate(stream, output1, output2)](#module_rindle.bifurcate)
+    * [.pipeWithEvents(stream, output, events)](#module_rindle.pipeWithEvents) ⇒ <code>StreamReadable</code>
+    * [.onEvent(stream, event)](#module_rindle.onEvent)
 
 <a name="module_rindle.wait"></a>
-### rindle.wait(stream, callback)
+
+### rindle.wait(stream)
 This functions listens for the following events:
 
 - `close`.
@@ -44,14 +44,13 @@ This functions listens for the following events:
 
 If those events pass any argument when being emitted, you'll be able to access them as arguments to the callback.
 
-**Kind**: static method of <code>[rindle](#module_rindle)</code>  
+**Kind**: static method of [<code>rindle</code>](#module_rindle)  
 **Summary**: Wait for a stream to close  
-**Access:** public  
+**Access**: public  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | stream | <code>Stream</code> | stream |
-| callback | <code>function</code> | callback (error, args...) |
 
 **Example**  
 ```js
@@ -63,23 +62,25 @@ var output = fs.createWriteStream('foo/baz');
 
 input.pipe(output);
 
-rindle.wait(output, function(error) {
-  if (error) throw error;
+try {
+  await rindle.wait(output);
   console.log('The output stream was closed!');
-});
+}(error) {
+  if (error) throw error;
+}
 ```
 <a name="module_rindle.extract"></a>
-### rindle.extract(stream, callback)
+
+### rindle.extract(stream)
 Notice this function only extracts the *remaining data* from the stream.
 
-**Kind**: static method of <code>[rindle](#module_rindle)</code>  
+**Kind**: static method of [<code>rindle</code>](#module_rindle)  
 **Summary**: Extract data from readable stream  
-**Access:** public  
+**Access**: public  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | stream | <code>StreamReadable</code> | stream |
-| callback | <code>function</code> | callback (error, data) |
 
 **Example**  
 ```js
@@ -88,25 +89,27 @@ var rindle = require('rindle');
 
 var input = fs.createReadStream('foo/bar');
 
-rindle.extract(input, function(error, data) {
-  if (error) throw error;
+try {
+  const data = await rindle.extract(input);
   console.log('The file contains: ' + data);
-});
+} catch (error) {
+  if (error) throw error;
+}
 ```
 <a name="module_rindle.bifurcate"></a>
-### rindle.bifurcate(stream, output1, output2, callback)
-The callback is called when both output stream close.
 
-**Kind**: static method of <code>[rindle](#module_rindle)</code>  
+### rindle.bifurcate(stream, output1, output2)
+The returned promised gets resolved when both output streams close.
+
+**Kind**: static method of [<code>rindle</code>](#module_rindle)  
 **Summary**: Bifurcate readable stream to two writable streams  
-**Access:** public  
+**Access**: public  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | stream | <code>StreamReadable</code> | input stream |
 | output1 | <code>StreamWritable</code> | first output stream |
 | output2 | <code>StreamWritable</code> | second output stream |
-| callback | <code>function</code> | callback (error) |
 
 **Example**  
 ```js
@@ -117,18 +120,20 @@ var input = fs.createReadStream('foo/bar');
 var output1 = fs.createWriteStream('foo/baz');
 var output2 = fs.createWriteStream('foo/qux');
 
-rindle.bifurcate(input, output1, output2, function(error) {
-  if (error) throw error;
-
+try {
+  await rindle.bifurcate(input, output1, output2,
   console.log('All files written!');
-});
+} (error) {
+  if (error) throw error;
+}
 ```
 <a name="module_rindle.pipeWithEvents"></a>
+
 ### rindle.pipeWithEvents(stream, output, events) ⇒ <code>StreamReadable</code>
-**Kind**: static method of <code>[rindle](#module_rindle)</code>  
+**Kind**: static method of [<code>rindle</code>](#module_rindle)  
 **Summary**: Pipe a stream along with certain events  
 **Returns**: <code>StreamReadable</code> - resulting stream  
-**Access:** public  
+**Access**: public  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -146,44 +151,29 @@ rindle.pipeWithEvents(input, output, [
 ]);
 ```
 <a name="module_rindle.onEvent"></a>
-### rindle.onEvent(stream, event, callback)
-**Kind**: static method of <code>[rindle](#module_rindle)</code>  
+
+### rindle.onEvent(stream, event)
+**Kind**: static method of [<code>rindle</code>](#module_rindle)  
 **Summary**: Wait for a stream to emit a certain event  
-**Access:** public  
+**Access**: public  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | stream | <code>Stream</code> | stream |
 | event | <code>String</code> | event name |
-| callback | <code>function</code> | callback (error, args...) |
 
 **Example**  
 ```js
 var rindle = require('rindle');
 var fs = require('fs');
 
-rindle.onEvent(fs.createReadStream('foo/bar'), 'open', function(error, fd) {
-  if (error) throw error;
-
+try {
+  const fd = await rindle.onEvent(fs.createReadStream('foo/bar'), 'open');
   console.log('The "open" event was emitted');
   console.log(fd);
-});
-```
-<a name="module_rindle.getStreamFromString"></a>
-### rindle.getStreamFromString(string) ⇒ <code>ReadableStream</code>
-**Kind**: static method of <code>[rindle](#module_rindle)</code>  
-**Summary**: Get a readable stream from a string  
-**Returns**: <code>ReadableStream</code> - - string stream  
-**Access:** public  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| string | <code>String</code> | input string |
-
-**Example**  
-```js
-var rindle = require('rindle');
-rindle.getStreamFromString('Hello World!').pipe(process.stdout);
+} (error) {
+  if (error) throw error;
+}
 ```
 
 Support

--- a/lib/rindle.js
+++ b/lib/rindle.js
@@ -27,8 +27,6 @@
  */
 'use strict';
 
-var stringToStream = require('string-to-stream');
-
 /**
  * @summary Wait for a stream to close
  * @function
@@ -210,24 +208,4 @@ exports.onEvent = function (stream, event) {
 			return resolve(args);
 		});
 	});
-};
-
-/**
- * @summary Get a readable stream from a string
- * @function
- * @public
- *
- * @param {String} string - input string
- * @returns {ReadableStream} - string stream
- *
- * @example
- * var rindle = require('rindle');
- * rindle.getStreamFromString('Hello World!').pipe(process.stdout);
- */
-exports.getStreamFromString = function (s) {
-	if (typeof s !== 'string') {
-		throw new Error('Not a string: ' + s);
-	}
-
-	return stringToStream(s);
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "tmp": "0.0.28"
   },
   "dependencies": {
-    "string-to-stream": "^1.0.1"
   },
   "versionist": {
     "publishedAt": "2025-09-22T08:53:39.624Z"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai-as-promised": "^7.1.1",
     "gulp": "^4.0.2",
     "gulp-mocha": "^2.1.3",
-    "jsdoc-to-markdown": "^1.1.1",
+    "jsdoc-to-markdown": "^9.0.0",
     "sinon": "^9.0.2",
     "sinon-chai": "^3.5.0",
     "tmp": "0.0.28"

--- a/tests/rindle.spec.js
+++ b/tests/rindle.spec.js
@@ -26,7 +26,6 @@ var chai = require('chai');
 var sinon = require('sinon');
 var _ = require('lodash');
 var fs = require('fs');
-var StringStream = require('string-to-stream');
 var StreamReadable = require('stream').Readable;
 var StreamPassThrough = require('stream').PassThrough;
 var EventEmitter = require('events').EventEmitter;
@@ -482,36 +481,6 @@ describe('Rindle:', function () {
 				const result = await rindle.onEvent(this.stream, 'foo');
 				expect(result).to.deep.equal(['bar', 'baz', 'qux']);
 			});
-		});
-	});
-
-	describe('.getStreamFromString()', function () {
-		it('should throw if no input', function () {
-			chai
-				.expect(function () {
-					rindle.getStreamFromString();
-				})
-				.to.throw('Not a string: undefined');
-		});
-
-		it('should throw if input is not a string', function () {
-			chai
-				.expect(function () {
-					rindle.getStreamFromString(13);
-				})
-				.to.throw('Not a string: 13');
-		});
-
-		it('should return an instance of ReadableStream', function () {
-			var stringStream = rindle.getStreamFromString('Hello World');
-			expect(stringStream).to.be.an.instanceof(StringStream);
-		});
-
-		it('should be a stream containing the string characters', function () {
-			var stringStream = rindle.getStreamFromString('Hello World');
-			chai
-				.expect(rindle.extract(stringStream))
-				.to.eventually.equal('Hello World');
 		});
 	});
 });


### PR DESCRIPTION
Change-type: major
See: https://balena.fibery.io/Work/Project/1890

Where we use rindle
See: https://github.com/search?type=code&auto_enroll=true&q=%2Frindle%5B%5E.%5D*%5C.%5Cw%2B%5C%28%2F+-path%3A*.md+-path%3A%2F.versionbot%2F*+NOT+is%3Aarchived+%28org%3Abalena-io+OR+org%3Abalena-io-examples+OR+org%3Abalena-io-library+OR+org%3Abalena-io-modules+OR+org%3Abalena-os+OR+org%3Abalenablocks+OR+org%3Abalena-labs-projects+OR+org%3Abalenaltd+OR+org%3Aproduct-os%29

Where we emit `'done'` , which blocks us from replacing `.wait()` with `import { finished } from 'stream/promises';`
See: https://github.com/search?type=code&auto_enroll=true&q=%22emit%28%27done%27%22+-path%3A*.md+-path%3A%2F.versionbot%2F*+NOT+is%3Aarchived+%28org%3Abalena-io+OR+org%3Abalena-io-examples+OR+org%3Abalena-io-library+OR+org%3Abalena-io-modules+OR+org%3Abalena-os+OR+org%3Abalenablocks+OR+org%3Abalena-labs-projects+OR+org%3Abalenaltd+OR+org%3Aproduct-os%29